### PR TITLE
docs: security/architecture/types

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Example environment variables for zPassword
+# This file contains no secrets. Copy to .env and adjust as needed.
+
+# NEXT_PUBLIC_API_URL=
+# TAURI_DEV_API_URL=

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,11 @@
+# Architecture
+
+zPassword is a monorepo managed with pnpm workspaces.
+
+- **apps/web** – Next.js web client.
+- **apps/desktop** – Tauri desktop application.
+- **apps/extension** – Browser extension (Manifest V3).
+- **packages/crypto-core** – Rust cryptographic primitives compiled to WebAssembly.
+- **packages/shared** – TypeScript utilities and shared types.
+
+Each package exposes `build`, `test`, `lint`, and `typecheck` scripts which are orchestrated from the root `package.json`.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # zPassword
+
+## How to run
+
+Install dependencies:
+
+```bash
+pnpm install
+```
+
+Start development servers:
+
+```bash
+pnpm dev:web       # Next.js web app
+pnpm dev:desktop   # Tauri desktop app
+pnpm dev:extension # Browser extension
+```
+
+Run tests:
+
+```bash
+pnpm test
+```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,6 @@
+# Security Principles
+
+- Zero-knowledge: user secrets never leave the device unencrypted.
+- Use proven cryptography: Argon2id for key derivation, XChaCha20-Poly1305 for authenticated encryption, and RFC 6238 for TOTP.
+- Defense in depth: each component includes unit, property, and fuzz tests.
+- No secrets are committed to the repository; use `.env` for local configuration.

--- a/docs/ADR-0001.md
+++ b/docs/ADR-0001.md
@@ -1,0 +1,15 @@
+# ADR-0001: Cryptography Choices
+
+## Context
+zPassword requires modern, secure cryptography for key derivation, encryption, and one-time passwords.
+
+## Decision
+- **Key derivation:** Argon2id with configurable memory, time, and parallelism.
+- **Authenticated encryption:** XChaCha20-Poly1305 for nonce-misuse resistance.
+- **TOTP:** RFC 6238 using HMAC-SHA1 producing 6-digit codes.
+
+## Status
+Accepted.
+
+## Consequences
+Using industry-standard primitives simplifies auditing and provides cross-platform support.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,0 +1,17 @@
+# Threat Model
+
+## Assets
+- Master key
+- Device keys
+- Vault contents (items and fields)
+- Audit log
+
+## STRIDE
+| Threat | Mitigation |
+| --- | --- |
+| Spoofing | Rely on TLS and key pinning for server connections. |
+| Tampering | AEAD tags on all encrypted data detect modification. |
+| Repudiation | Merklized event log records user actions. |
+| Information Disclosure | End-to-end encryption ensures server sees only ciphertext. |
+| Denial of Service | Local caching and rate limiting reduce impact. |
+| Elevation of Privilege | Role-based access control and device trust requirements. |

--- a/packages/shared/__tests__/placeholder.test.ts
+++ b/packages/shared/__tests__/placeholder.test.ts
@@ -1,7 +1,15 @@
 import { describe, it, expect } from 'vitest';
+import { Vault, Item, Field, Key, EventLogEntry } from '../src';
 
-describe('placeholder', () => {
-  it('works', () => {
-    expect(true).toBe(true);
+describe('shared types', () => {
+  it('constructs sample structures', () => {
+    const field: Field = { id: 'f1', name: 'username', value: 'alice', createdAt: 0, updatedAt: 0 };
+    const item: Item = { id: 'i1', fields: [field], createdAt: 0, updatedAt: 0 };
+    const vault: Vault = { id: 'v1', name: 'Personal', items: [item], createdAt: 0, updatedAt: 0 };
+    const key: Key = { id: 'k1', type: 'master', material: new Uint8Array([1, 2, 3]) };
+    const event: EventLogEntry = { id: 'e1', timestamp: 0, action: 'create', itemId: item.id };
+    expect(vault.items[0].fields[0].name).toBe('username');
+    expect(key.material.length).toBe(3);
+    expect(event.action).toBe('create');
   });
 });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,1 @@
+export * from './types';

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,0 +1,37 @@
+export interface Field {
+  id: string;
+  name: string;
+  value: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface Item {
+  id: string;
+  fields: Field[];
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface Vault {
+  id: string;
+  name: string;
+  items: Item[];
+  createdAt: number;
+  updatedAt: number;
+}
+
+export type KeyType = 'master' | 'device' | 'vault' | 'item';
+
+export interface Key {
+  id: string;
+  type: KeyType;
+  material: Uint8Array;
+}
+
+export interface EventLogEntry {
+  id: string;
+  timestamp: number;
+  action: string;
+  itemId?: string;
+}


### PR DESCRIPTION
## Summary
- add security and architecture documentation
- record cryptography choices in ADR-0001 and expand threat model
- define shared Vault/Item/Field/Key/EventLogEntry types

## Testing
- `pnpm build`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `cargo test --manifest-path packages/crypto-core/Cargo.toml`

## How to run now
- `pnpm install`
- `pnpm dev:web`
- `pnpm dev:desktop`
- `pnpm dev:extension`

## Security Notes
- repository contains no secrets; use `.env` locally


------
https://chatgpt.com/codex/tasks/task_e_68990af8251c832993157a710ea2073b